### PR TITLE
Skip packages that aren't found in the UWP library

### DIFF
--- a/GPSaveConverter/Xbox/XboxPackageList.cs
+++ b/GPSaveConverter/Xbox/XboxPackageList.cs
@@ -21,8 +21,15 @@ namespace GPSaveConverter.Xbox
                 string wgsFolder = Path.Combine(package, "SystemAppData", "wgs");
                 if(Directory.Exists(wgsFolder) && Directory.GetDirectories(wgsFolder).Length >= 2)
                 {
-                    Library.GameInfo info = Library.GameLibrary.getGameInfo(Path.GetFileName(package));
-                    list.Add(info);
+                    try
+                    {
+                        Library.GameInfo info = Library.GameLibrary.getGameInfo(Path.GetFileName(package));
+                        list.Add(info);
+                    }
+                    catch(Exception ex)
+                    {
+                        logger.Info(String.Format("Could not load Xbox package {0}: {1}", Path.GetFileName(package), ex.Message));
+                    }
                 }
             }
             internalList = list.ToArray();


### PR DESCRIPTION
Thanks for making this tool!

While trying to transfer my Guardians of the Galaxy save file, I ran into the same issue as in [this reddit comment](https://www.reddit.com/r/XboxGamePass/comments/tb15za/comment/i0mcknk/).  I have a couple package folders, `Microsoft.Chelan_8wekyb3d8bbwe` and `Microsoft.Maine_8wekyb3d8bbwe`, which are causing the `Game info not found in UWP library` exception to be thrown.  The first appears related to the Halo MCC, and the second Obsidian's Grounded game.

I'm not sure why these aren't recognized, but either way I was able to successfully copy my Guardians save after I added the code in this commit to log and skip folders for packages not found in the UWP library.