### PR TITLE
Add Hi-Fi Rush support

### DIFF
--- a/GPSaveConverter/Resources/GameLibrary.json
+++ b/GPSaveConverter/Resources/GameLibrary.json
@@ -201,6 +201,29 @@
           ]
         }
       ]
+    },
+    {
+      "PackageName": "BethesdaSoftworks.Hibiki_3275kfvn8vcwc",
+      "BaseNonXboxSaveLocation": "%USERPROFILE%\\Saved Games\\TangoGameworks\\Hi-Fi RUSH (STEAM)\\Saved\\SaveGames\\",
+      "TargetProfileTypes": [ "Steam" ],
+      "FileTranslations": [
+        {
+          "NonXboxFilename": "SaveGameSlot${FileSlot}.sav",
+          "XboxFileID": "Data",
+          "ContainerName1": "SaveGameSlot${FileSlot}",
+          "ContainerName2": "SaveGameSlot${FileSlot}",
+          "NamedRegexGroups": [
+            "(?<FileSlot>[0-9]+)"
+          ]
+        },
+        {
+          "NonXboxFilename": "Profile.sav",
+          "XboxFileID": "Data",
+          "ContainerName1": "Profile",
+          "ContainerName2": "Profile",
+          "NamedRegexGroups": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added file translations for Hi-Fi Rush. 

For some reason, when trying to convert the saves from xbox to steam, the prompt `Select non-Xbox Profile(s) (or select save file location manually)` comes up, but everything else works as usual after manually selecting the steam save location.