### PR TITLE
Add a "Filter" box to search through the list of Xbox packages

### DIFF
--- a/GPSaveConverter/CueTextBox.cs
+++ b/GPSaveConverter/CueTextBox.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+using System.Runtime.InteropServices;
+
+namespace GPSaveConverter
+{
+    // https://stackoverflow.com/questions/4902565/watermark-textbox-in-winforms/4902969#4902969
+    // To be replaced with TextBox.PlaceholderText under .NET 5
+    public partial class CueTextBox : TextBox
+    {
+        [Localizable(true)]
+        public string Cue
+        {
+            get { return mCue; }
+            set { mCue = value; updateCue(); }
+        }
+
+        private void updateCue()
+        {
+            if (this.IsHandleCreated && mCue != null)
+            {
+                SendMessage(this.Handle, 0x1501, (IntPtr)1, mCue);
+            }
+        }
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            updateCue();
+        }
+        private string mCue;
+
+        // PInvoke
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, string lp);
+
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            this.ResumeLayout(false);
+        }
+    }
+}

--- a/GPSaveConverter/GPSaveConverter.csproj
+++ b/GPSaveConverter/GPSaveConverter.csproj
@@ -78,6 +78,9 @@
     <Compile Include="EditBaseLocationForm.Designer.cs">
       <DependentUpon>EditBaseLocationForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="CueTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Library\FileTranslation.cs" />
     <Compile Include="Library\PCGameWiki.cs" />
     <Compile Include="Library\Steam.cs" />

--- a/GPSaveConverter/SaveFileConverterForm.Designer.cs
+++ b/GPSaveConverter/SaveFileConverterForm.Designer.cs
@@ -89,9 +89,7 @@
             this.gameListContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyPackageIDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editNonXboxLocationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.XboxContainerName1Column = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.XboxContainerName2Column = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.XboxFileIDColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.filterText = new GPSaveConverter.CueTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.xboxFilesTable)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nonXboxFilesTable)).BeginInit();
             this.saveFilesBasePanel.SuspendLayout();
@@ -132,7 +130,7 @@
             // nonXboxFilesLabel
             // 
             this.nonXboxFilesLabel.AutoSize = true;
-            this.nonXboxFilesLabel.Location = new System.Drawing.Point(3, 15);
+            this.nonXboxFilesLabel.Location = new System.Drawing.Point(3, 11);
             this.nonXboxFilesLabel.Name = "nonXboxFilesLabel";
             this.nonXboxFilesLabel.Size = new System.Drawing.Size(109, 13);
             this.nonXboxFilesLabel.TabIndex = 10;
@@ -141,7 +139,7 @@
             // xboxFileLabel
             // 
             this.xboxFileLabel.AutoSize = true;
-            this.xboxFileLabel.Location = new System.Drawing.Point(3, 15);
+            this.xboxFileLabel.Location = new System.Drawing.Point(3, 11);
             this.xboxFileLabel.Name = "xboxFileLabel";
             this.xboxFileLabel.Size = new System.Drawing.Size(86, 13);
             this.xboxFileLabel.TabIndex = 12;
@@ -159,12 +157,12 @@
             this.XboxContainerName2Column,
             this.XboxFileIDColumn,
             this.XboxTimestampColumn});
-            this.xboxFilesTable.Location = new System.Drawing.Point(3, 31);
+            this.xboxFilesTable.Location = new System.Drawing.Point(3, 27);
             this.xboxFilesTable.Name = "xboxFilesTable";
             this.xboxFilesTable.ReadOnly = true;
             this.xboxFilesTable.RowHeadersVisible = false;
             this.xboxFilesTable.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.xboxFilesTable.Size = new System.Drawing.Size(497, 265);
+            this.xboxFilesTable.Size = new System.Drawing.Size(494, 266);
             this.xboxFilesTable.TabIndex = 13;
             this.xboxFilesTable.SelectionChanged += new System.EventHandler(this.xboxFilesTable_SelectionChanged);
             // 
@@ -213,13 +211,13 @@
             this.nonXboxFilesTable.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.RelativePath,
             this.Timestamp});
-            this.nonXboxFilesTable.Location = new System.Drawing.Point(0, 31);
+            this.nonXboxFilesTable.Location = new System.Drawing.Point(3, 27);
             this.nonXboxFilesTable.Margin = new System.Windows.Forms.Padding(0);
             this.nonXboxFilesTable.Name = "nonXboxFilesTable";
             this.nonXboxFilesTable.ReadOnly = true;
             this.nonXboxFilesTable.RowHeadersVisible = false;
             this.nonXboxFilesTable.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.nonXboxFilesTable.Size = new System.Drawing.Size(500, 265);
+            this.nonXboxFilesTable.Size = new System.Drawing.Size(494, 265);
             this.nonXboxFilesTable.TabIndex = 14;
             this.nonXboxFilesTable.SelectionChanged += new System.EventHandler(this.nonXboxFilesTable_SelectionChanged);
             // 
@@ -399,6 +397,7 @@
             | System.Windows.Forms.AnchorStyles.Left)));
             this.packagesBasePanel.Controls.Add(this.packagesScrollPanel);
             this.packagesBasePanel.Controls.Add(this.packagesLabel);
+            this.packagesBasePanel.Controls.Add(this.filterText);
             this.packagesBasePanel.Location = new System.Drawing.Point(9, 27);
             this.packagesBasePanel.Margin = new System.Windows.Forms.Padding(0);
             this.packagesBasePanel.Name = "packagesBasePanel";
@@ -412,9 +411,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.packagesScrollPanel.AutoScroll = true;
             this.packagesScrollPanel.Controls.Add(this.packagesDataGridView);
-            this.packagesScrollPanel.Location = new System.Drawing.Point(0, 19);
+            this.packagesScrollPanel.Location = new System.Drawing.Point(0, 40);
             this.packagesScrollPanel.Name = "packagesScrollPanel";
-            this.packagesScrollPanel.Size = new System.Drawing.Size(407, 274);
+            this.packagesScrollPanel.Size = new System.Drawing.Size(407, 253);
             this.packagesScrollPanel.TabIndex = 9;
             // 
             // packagesDataGridView
@@ -429,7 +428,7 @@
             this.GameIcon,
             this.GameName});
             this.packagesDataGridView.ContextMenuStrip = this.gameListContextMenu;
-            this.packagesDataGridView.Location = new System.Drawing.Point(0, 0);
+            this.packagesDataGridView.Location = new System.Drawing.Point(3, 1);
             this.packagesDataGridView.Margin = new System.Windows.Forms.Padding(0);
             this.packagesDataGridView.MultiSelect = false;
             this.packagesDataGridView.Name = "packagesDataGridView";
@@ -437,7 +436,7 @@
             this.packagesDataGridView.RowHeadersVisible = false;
             this.packagesDataGridView.RowTemplate.Height = 75;
             this.packagesDataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.packagesDataGridView.Size = new System.Drawing.Size(407, 274);
+            this.packagesDataGridView.Size = new System.Drawing.Size(401, 252);
             this.packagesDataGridView.TabIndex = 9;
             this.packagesDataGridView.Click += new System.EventHandler(this.packagesDataGridView_Click);
             // 
@@ -537,7 +536,7 @@
             // 
             // tabControl1
             // 
-            this.tabControl1.Location = new System.Drawing.Point(3, 17);
+            this.tabControl1.Location = new System.Drawing.Point(3, 16);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(200, 100);
@@ -730,6 +729,15 @@
             this.copyPackageIDToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
             this.copyPackageIDToolStripMenuItem.Text = "Copy game package name";
             this.copyPackageIDToolStripMenuItem.Click += new System.EventHandler(this.copyPackageIDToolStripMenuItem_Click);
+            // filterText
+            // 
+            this.filterText.Cue = "Filter";
+            this.filterText.Location = new System.Drawing.Point(3, 18);
+            this.filterText.Name = "filterText";
+            this.filterText.Size = new System.Drawing.Size(401, 20);
+            this.filterText.TabIndex = 10;
+            this.filterText.TextChanged += new System.EventHandler(this.filterText_TextChanged);
+            // 
             // SaveFileConverterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -839,6 +847,7 @@
         private System.Windows.Forms.ToolStripMenuItem editNonXboxLocationToolStripMenuItem2;
         private System.Windows.Forms.ContextMenuStrip gameListContextMenu;
         private System.Windows.Forms.ToolStripMenuItem copyPackageIDToolStripMenuItem;
+        private CueTextBox filterText;
     }
 }
 

--- a/GPSaveConverter/SaveFileConverterForm.cs
+++ b/GPSaveConverter/SaveFileConverterForm.cs
@@ -130,7 +130,7 @@ namespace GPSaveConverter
                 // 
                 // UserIcon
                 // 
-                    userIconColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+                userIconColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
                 userIconColumn.DataPropertyName = "UserIcon";
                 userIconColumn.HeaderText = "User Icon";
                 userIconColumn.Name = "UserIcon";
@@ -151,8 +151,7 @@ namespace GPSaveConverter
 
                 profileDataGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
                 profileDataGrid.ColumnHeadersVisible = false;
-                profileDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { userIconColumn,
-                                                                                                 userNameColumn});
+                profileDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { userIconColumn, userNameColumn });
                 profileDataGrid.Location = new System.Drawing.Point(183, 78);
                 profileDataGrid.Name = "nonXboxProfileTable" + index;
                 profileDataGrid.ReadOnly = true;
@@ -240,7 +239,7 @@ namespace GPSaveConverter
 
             Library.GameInfo[] gameInfo = await LoadGameInfo();
 
-            this.packagesDataGridView.Height = gameInfo.Length * 75 + 10;
+            this.packagesDataGridView.Height = Math.Max(252, gameInfo.Length * 75 + 10);
 
             this.packagesDataGridView.DataSource = gameInfo;
         }
@@ -449,6 +448,10 @@ namespace GPSaveConverter
 
         private async void packagesDataGridView_Click(object sender, EventArgs e)
         {
+            if (this.packagesDataGridView.SelectedRows.Count < 1)
+            {
+                return;
+            }
             ClearForm();
 
             ActiveGame = (Library.GameInfo)this.packagesDataGridView.SelectedRows[0].DataBoundItem;
@@ -741,6 +744,24 @@ namespace GPSaveConverter
             }
 
             Clipboard.SetText(sb.ToString());
+        }
+
+        private void filterText_TextChanged(object sender, EventArgs e)
+        {
+            if (this.packagesDataGridView.Rows.Count < 1)
+            {
+                return;
+            }
+            CurrencyManager cm = (CurrencyManager)BindingContext[this.packagesDataGridView.DataSource];
+            cm.SuspendBinding();
+            foreach (DataGridViewRow r in this.packagesDataGridView.Rows)
+            {
+                r.Visible = this.filterText.TextLength < 2 || (r.DataBoundItem as Library.GameInfo).Name.IndexOf(this.filterText.Text, StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            cm.ResumeBinding();
+
+            // GetRowsHeight doesn't seem to function as intended for the Height calc
+            this.packagesDataGridView.Height = Math.Max(252, this.packagesDataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible) * 75 + 10);
         }
     }
 }

--- a/GPSaveConverter/SaveFileConverterForm.resx
+++ b/GPSaveConverter/SaveFileConverterForm.resx
@@ -129,18 +129,6 @@
   <metadata name="XboxTimestampColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="XboxContainerName1Column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="XboxContainerName2Column.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="XboxFileIDColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="XboxTimestampColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="RelativePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -160,7 +148,7 @@
     <value>True</value>
   </metadata>
   <metadata name="gameListContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-		<value>669, 17</value>
+    <value>669, 17</value>
   </metadata>
   <metadata name="foldersToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>


### PR DESCRIPTION
Also tweak positioning of some UI elements slightly.

This allows people to search through their game list for a particular game.
Filtering only begins at 2+ characters entered, and is removed once <2 characters are in the search box.

Screenshots:
![image](https://github.com/Fr33dan/GPSaveConverter/assets/2764675/47ccea46-b064-4b55-adeb-35880d2f2f10)
![image](https://github.com/Fr33dan/GPSaveConverter/assets/2764675/4b4ba551-ae66-4a06-8651-c039e3da833d)
![image](https://github.com/Fr33dan/GPSaveConverter/assets/2764675/ee9e396c-f11e-42af-95a3-5917eb25bd15)


