### PR TITLE
Use modernized folder selection dialog for selecting non-xbox location

### DIFF
--- a/GPSaveConverter/GPSaveConverter.csproj
+++ b/GPSaveConverter/GPSaveConverter.csproj
@@ -202,6 +202,9 @@
     <PackageReference Include="NLog.Windows.Forms">
       <Version>4.6.0</Version>
     </PackageReference>
+    <PackageReference Include="Ookii.Dialogs.WinForms">
+      <Version>4.0.0</Version>
+    </PackageReference>
     <PackageReference Include="System.AppContext">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/GPSaveConverter/Library/PCGameWiki.cs
+++ b/GPSaveConverter/Library/PCGameWiki.cs
@@ -35,6 +35,10 @@ namespace GPSaveConverter.Library
                     {
                         return;
                     }
+                    if (queryRoot["query"]["pages"][0]["missing"] != null && queryRoot["query"]["pages"][0]["missing"].AsValue().GetValue<bool>())
+                    {
+                        return;
+                    }
                     int pageID = queryRoot["query"]["pages"][0]["pageid"].AsValue().GetValue<int>();
 
 

--- a/GPSaveConverter/Library/PCGameWiki.cs
+++ b/GPSaveConverter/Library/PCGameWiki.cs
@@ -58,6 +58,10 @@ namespace GPSaveConverter.Library
                             sectionIndex = n["index"].GetValue<string>();
                         }
                     }
+                    if (sectionIndex == null || sectionIndex == "-1")
+                    {
+                        return;
+                    }
 
                     url = String.Format(@"https://www.pcgamingwiki.com/w/api.php?action=parse&pageid={0}&formatversion=2&format=json&prop=wikitext&section={1}", pageID, sectionIndex);
                     string saveFileSectionJson = await wc.DownloadStringTaskAsync(url);

--- a/GPSaveConverter/SaveFileConverterForm.cs
+++ b/GPSaveConverter/SaveFileConverterForm.cs
@@ -58,6 +58,10 @@ namespace GPSaveConverter
             if (res == DialogResult.OK)
             {
                 VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog();
+                if (ActiveGame.BaseNonXboxSaveLocation != null && ActiveGame.BaseNonXboxSaveLocation != string.Empty)
+                {
+                    dialog.SelectedPath = ActiveGame.BaseNonXboxSaveLocation;
+                }
                 res = dialog.ShowDialog();
                 if (res == DialogResult.OK)
                 {

--- a/GPSaveConverter/SaveFileConverterForm.cs
+++ b/GPSaveConverter/SaveFileConverterForm.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Ookii.Dialogs.WinForms;
 
 namespace GPSaveConverter
 {
@@ -56,7 +57,7 @@ namespace GPSaveConverter
             }
             if (res == DialogResult.OK)
             {
-                FolderBrowserDialog dialog = new FolderBrowserDialog();
+                VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog();
                 res = dialog.ShowDialog();
                 if (res == DialogResult.OK)
                 {


### PR DESCRIPTION
Also handle missing data from PCGamingWiki properly.
Also sets dialog's starting path to the existing path if any. Note if placeholders like %USERPROFILE% are in the existing path, only the filename value (folder name value) will get filled in, rather than auto-navigating to the existing path.

This pulls in https://github.com/ookii-dialogs/ookii-dialogs-winforms to create the dialog as we aim to support .NET 4.6 (which Windows ships with) and .NET 5 is when Microsoft made [FolderBrowserDialog](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.folderbrowserdialog.autoupgradeenabled) not-awful.

Note: According to https://github.com/ookii-dialogs/ookii-dialogs-winforms/releases, the library dropped support for .NET 4.6.1 (leaving only 4.6.2) with v4.0.0. Windows 10 comes with .NET 4.6 by default, with [different updates having different versions](https://stackoverflow.com/questions/35362303/which-net-version-does-windows-10-have-built-in). I do not think this will be a concern, but worst case we downgrade to ookii 3.0.0 if anyone raises an issue. Or we say "Requires Windows 10 1607 update".