### PR TITLE
Fix crash when the wiki table text cannot be found

### DIFF
--- a/GPSaveConverter/Library/PCGameWiki.cs
+++ b/GPSaveConverter/Library/PCGameWiki.cs
@@ -95,7 +95,7 @@ namespace GPSaveConverter.Library
             int entryStart = unparsedWikiTable.IndexOf("{{Game data/saves|");
             int entryEnd = entryStart;
             Dictionary<string, string> result = new Dictionary<string, string>();
-            do
+            while (entryStart != -1)
             {
                 int subEntryEnd = entryStart;
                 int subEntryStart = entryStart;
@@ -113,8 +113,7 @@ namespace GPSaveConverter.Library
                 result.Add(lineInfo[1], lineInfo[2]);
 
                 entryStart = unparsedWikiTable.IndexOf("{{Game data/saves|", entryEnd);
-            } while (entryStart != -1);
-
+            }
 
             return result;
         }


### PR DESCRIPTION
flipped a do-while loop to prevent calling String.Substring on a negative index, in case the wiki table text does not contain the "{{Game data/saves|" section we are looking for.

this seems to be the cause of issue #77 