### PR TITLE
Replace non-Xbox location error prompt with flashing error icon

### DIFF
--- a/GPSaveConverter/SaveFileConverterForm.Designer.cs
+++ b/GPSaveConverter/SaveFileConverterForm.Designer.cs
@@ -90,6 +90,7 @@
             this.copyPackageIDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editNonXboxLocationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.filterText = new GPSaveConverter.CueTextBox();
+            this.nonXboxLocationError = new System.Windows.Forms.ErrorProvider(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.xboxFilesTable)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nonXboxFilesTable)).BeginInit();
             this.saveFilesBasePanel.SuspendLayout();
@@ -107,6 +108,7 @@
             this.fileTranslationPanel.SuspendLayout();
             this.nonXboxMenuStrip.SuspendLayout();
             this.gameListContextMenu.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nonXboxLocationError)).BeginInit();
             this.SuspendLayout();
             // 
             // packagesLabel
@@ -738,6 +740,12 @@
             this.filterText.TabIndex = 10;
             this.filterText.TextChanged += new System.EventHandler(this.filterText_TextChanged);
             // 
+            // nonXboxLocationError
+            // 
+            this.nonXboxLocationError.ContainerControl = this;
+            this.nonXboxLocationError.SetIconAlignment(this.promptNonXboxLocationButton, System.Windows.Forms.ErrorIconAlignment.MiddleLeft);
+            this.nonXboxLocationError.SetIconPadding(this.promptNonXboxLocationButton, 2);
+            // 
             // SaveFileConverterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -781,6 +789,7 @@
             this.fileTranslationPanel.PerformLayout();
             this.nonXboxMenuStrip.ResumeLayout(false);
             this.gameListContextMenu.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.nonXboxLocationError)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -848,6 +857,7 @@
         private System.Windows.Forms.ContextMenuStrip gameListContextMenu;
         private System.Windows.Forms.ToolStripMenuItem copyPackageIDToolStripMenuItem;
         private CueTextBox filterText;
+        private System.Windows.Forms.ErrorProvider nonXboxLocationError;
     }
 }
 

--- a/GPSaveConverter/SaveFileConverterForm.resx
+++ b/GPSaveConverter/SaveFileConverterForm.resx
@@ -159,4 +159,7 @@
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>397, 17</value>
   </metadata>
+  <metadata name="nonXboxLocationError.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>844, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
When non-Xbox location has an error/is missing, instead of interrupting the app with a popup warning, this creates an error icon next to the "Select non-Xbox Location" button. The icon flashes for about 3 seconds whenever it gets a new error (if the error message remains the same as before it does not flash). Hovering over the icon shows the reason for the error (which was previously the text inside the popup box).

Tested setting and clearing the error with various games, it seems to work fine.

The only thing I can think of that would be a concern about this is potential accessibility issues for screen readers/tiny text.

![image](https://github.com/Fr33dan/GPSaveConverter/assets/2764675/2d0da536-9ee6-42da-9b3e-d5e9b7bc4f3c)
![image](https://github.com/Fr33dan/GPSaveConverter/assets/2764675/c36f336f-6770-46c3-940c-a2845c488ef8)
