### PR TITLE
Fix illegal character error when opening file browser dialog

### DIFF
--- a/GPSaveConverter/Library/PCGameWiki.cs
+++ b/GPSaveConverter/Library/PCGameWiki.cs
@@ -12,12 +12,12 @@ namespace GPSaveConverter.Library
     internal static class PCGameWiki
     {
         private static NLog.Logger logger = LogHelper.getClassLogger();
-        public static readonly string[,] FolderNameSubstitutions = new string[,] { { "{{p|userprofile}}", "	%USERPROFILE%" }
-                                                                                 , { "{{p|appdata}}", "	%APPDATA%" }
-                                                                                 , { "{{p|localappdata}}", "%LOCALAPPDATA%" }
-                                                                                 , { "{{p|programdata}}", "	%PROGRAMDATA%" }
-                                                                                 , { "{{p|uid}}", "<user-id>"}
-                                                                                 , { "{{p|steam}}", "<Steam-folder>"} };
+        public static readonly string[,] FolderNameSubstitutions = new string[,] { { "{{p|userprofile}}",   "%USERPROFILE%"     }
+                                                                                 , { "{{p|appdata}}",       "%APPDATA%"         }
+                                                                                 , { "{{p|localappdata}}",  "%LOCALAPPDATA%"    }
+                                                                                 , { "{{p|programdata}}",   "%PROGRAMDATA%"     }
+                                                                                 , { "{{p|uid}}",           "<user-id>"         }
+                                                                                 , { "{{p|steam}}",         "<Steam-folder>"    } };
         public static async Task FetchSaveLocation(GameInfo i)
         {
             logger.Info("Fetching save data from pcgamingwiki.com");
@@ -115,7 +115,7 @@ namespace GPSaveConverter.Library
                 } while (subEntryStart != -1);
 
                 string entryLine = unparsedWikiTable.Substring(entryStart, entryEnd - entryStart);
-                entryLine = NameSubsitution(entryLine);
+                entryLine = NameSubstitution(entryLine);
                 string[] lineInfo = entryLine.Split('|');
 
                 result.Add(lineInfo[1], lineInfo[2]);
@@ -126,7 +126,7 @@ namespace GPSaveConverter.Library
             return result;
         }
 
-        private static string NameSubsitution(string path)
+        private static string NameSubstitution(string path)
         {
             for (int i = 0; i < FolderNameSubstitutions.GetLength(0); i++)
             {

--- a/GPSaveConverter/SaveFileConverterForm.cs
+++ b/GPSaveConverter/SaveFileConverterForm.cs
@@ -59,7 +59,7 @@ namespace GPSaveConverter
         private async Task<bool> promptForNonXboxSaveLocation()
         {
             VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog();
-            if (ActiveGame.BaseNonXboxSaveLocation != null && ActiveGame.BaseNonXboxSaveLocation != string.Empty)
+            if (!string.IsNullOrEmpty(ActiveGame.BaseNonXboxSaveLocation) && ActiveGame.BaseNonXboxSaveLocation.IndexOfAny(Path.GetInvalidPathChars()) < 0)
             {
                 dialog.SelectedPath = ActiveGame.BaseNonXboxSaveLocation;
             }


### PR DESCRIPTION
Fixes #103

There was a tab character being added to every %USERPROFILE%/etc, plus if any other invalid character is in the path it now won't attempt to open the file browser to it directly.