### PR TITLE
Add `FINAL FANTASY IX` translation

### DIFF
--- a/GPSaveConverter/Resources/GameLibrary.json
+++ b/GPSaveConverter/Resources/GameLibrary.json
@@ -390,6 +390,42 @@
           ]
         }
       ]
+    },
+    {
+      "Name": "FINAL FANTASY IX",
+      "PackageName": "39EA002F.FINALFANTASYIX_n746a19ndrrjg",
+      "BaseNonXboxSaveLocation": "",
+      "FileTranslations": [
+        {
+          "NonXboxFilename": "AUTO",
+          "XboxFileID": "Data",
+          "ContainerName1": "AutoSave",
+          "ContainerName2": "FF9AutoSave",
+          "NamedRegexGroups": [
+            ""
+          ]
+        },
+        {
+          "NonXboxFilename": "DATA_SLOT${SlotNumber}_FILE${SaveNumber}",
+          "XboxFileID": "Data",
+          "ContainerName1": "DataSlot${SlotNumber}Save${SaveNumber}",
+          "ContainerName2": "FF9DataSlot${SlotNumber}Save${SaveNumber}",
+          "NamedRegexGroups": [
+            "(?<SlotNumber>(?<=SLOT)\\d+)",
+            "(?<SaveNumber>(?<=FILE)\\d+)"
+          ]
+        },
+        {
+          "NonXboxFilename": "PREVIEW_SLOT${SlotNumber}_FILE${SaveNumber}",
+          "XboxFileID": "Data${SaveNumber}",
+          "ContainerName1": "PreviewSlot${SlotNumber}",
+          "ContainerName2": "FF9PreviewSlot${SlotNumber}",
+          "NamedRegexGroups": [
+            "(?<SlotNumber>(?<=SLOT)\\d+)",
+            "(?<SaveNumber>(?<=FILE)\\d+)"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
There is no default non-xbox save location, since the Xbox->Non-Xbox conversion may require a tool like [ff9SaveLib](https://github.com/EuanFH/ff9SaveLib) to extract from the encrypted formats, but I just had success with this file translation mapping and figured I'd share.